### PR TITLE
Fix insertElement call to apply to pass array as second param

### DIFF
--- a/src/ui-scroll.coffee
+++ b/src/ui-scroll.coffee
@@ -95,7 +95,7 @@ angular.module('ui.scroll', [])
 
 				insertElement =
 					(newElement, previousElement) ->
-						element.after.apply(previousElement, newElement)
+						element.after.apply(previousElement, [newElement])
 						[]
 
 				insertElementAnimated =


### PR DESCRIPTION
fixed insertElement calling apply. Second param needs to be an array
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply

Ran into this with my local unit test of a directive that uses ui-scroll.