### PR TITLE
Fix strange expressions evalutions with undefined data.

### DIFF
--- a/src/ui-scroll.coffee
+++ b/src/ui-scroll.coffee
@@ -118,7 +118,7 @@ angular.module('ui.scroll', [])
 				# right after the builder creation is completed
 				linker $scope.$new(), (template, scope) ->
 					# Destroy template's scope to remove any watchers on it.
-					scope.$destroy();
+					scope.$destroy()
 
 					repeaterType = template[0].localName
 					if repeaterType in ['dl']

--- a/src/ui-scroll.coffee
+++ b/src/ui-scroll.coffee
@@ -116,7 +116,9 @@ angular.module('ui.scroll', [])
 				# Calling linker is the only way I found to get access to the tag name of the template
 				# to prevent the directive scope from pollution a new scope is created and destroyed
 				# right after the builder creation is completed
-				linker $scope.$new(), (template) ->
+				linker $scope.$new(), (template, scope) ->
+					# Destroy template's scope to remove any watchers on it.
+					scope.$destroy();
 
 					repeaterType = template[0].localName
 					if repeaterType in ['dl']


### PR DESCRIPTION
This PR fixes the issue https://github.com/angular-ui/ui-scroll/issues/17

When linker call is used to guess element's tag name, new scope is created.
Along with this directives and expressions used in the transcluded element set their watchers on the scope.
This leads to execution of such extra watchers expressions every digest call and this may cause some negative effects.
To fix it we need destroy the scope.