### PR TITLE
[refactor] Deprecated linker argument in compile function to be passed instead through prelink function

### DIFF
--- a/src/ui-scroll.coffee
+++ b/src/ui-scroll.coffee
@@ -34,8 +34,8 @@ angular.module('ui.scroll', [])
 		priority: 1000
 		terminal: true
 
-		compile: (elementTemplate, attr, linker) ->
-			($scope, element, $attr, controllers) ->
+		compile: (elementTemplate, attr) ->
+			pre: ($scope, element, $attr, controllers, linker) ->
 
 				log = console.debug || console.log
 


### PR DESCRIPTION
__[refactor]:__ deprecated linker argument in `compile` function to be passed instead through a `prelink` function.
  
_description:_ per Angular [docs](https://docs.angularjs.org/api/ng/service/$compile), implementing a transclude/linker function passed to the `compile` function is deprecated and should instead be passed through the `link` function.