### PR TITLE
remove padding template

### DIFF
--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -553,8 +553,8 @@ angular.module('ui.scroll', [])
             viewport.createPaddingElements(template[0]);
             // Destroy template's scope to remove any watchers on it.
             scope.$destroy();
-            // also remove the template when the directive scope is destroyed
-            $scope.$on('$destroy', () => template.remove());
+            // We don't need template anymore.
+            template.remove();
           });
 
           adapter.reload = reload;


### PR DESCRIPTION
This is a small improvement.
After paddings were created we don't need the template used for it (we do not need to wait $destroy event)