### PR TITLE
Call first reload with $timeout

### DIFF
--- a/demo/examples/positionedList.js
+++ b/demo/examples/positionedList.js
@@ -8,7 +8,7 @@ angular.module('application', [
     '$rootScope',
     '$location',
     function (console, $timeout, $rootScope, $location) {
-      var current, data, get, i, j, k, l, len, len1, letter1, letter2, position, ref, ref1, revision;
+      var current, data, get, i, j, k, l, len, len1, letter1, letter2, position, ref, ref1;
       $rootScope.key = "";
       position = 0;
       data = [];
@@ -50,12 +50,9 @@ angular.module('application', [
         }
         return current++;
       });
-      revision = function () {
-        return current;
-      };
+
       return {
-        get: get,
-        revision: revision
+        get: get
       };
     }
   ]);

--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -566,8 +566,6 @@ angular.module('ui.scroll', [])
           viewport.bind('scroll', resizeAndScrollHandler);
           viewport.bind('mousewheel', wheelHandler);
 
-          $timeout(() => reload());
-
           $scope.$on('$destroy', () => {
             // clear the buffer. It is necessary to remove the elements and $destroy the scopes
             buffer.clear();
@@ -575,6 +573,25 @@ angular.module('ui.scroll', [])
             viewport.unbind('scroll', resizeAndScrollHandler);
             viewport.unbind('mousewheel', wheelHandler);
           });
+
+          // update events (deprecated since v1.1.0, unsupported since 1.2.0)
+          (() => {
+            const eventListener = datasource.scope ? datasource.scope.$new() : $scope.$new();
+
+            eventListener.$on('insert.item', () => unsupportedMethod('insert'));
+
+            eventListener.$on('update.items', () => unsupportedMethod('update'));
+
+            eventListener.$on('delete.items', () => unsupportedMethod('delete'));
+
+            function unsupportedMethod(token) {
+              throw new Error(token + ' event is no longer supported - use applyUpdates instead');
+            }
+          })();
+
+          reload();
+
+          /* Functions definitions */
 
           function dismissPendingRequests() {
             ridActual++;
@@ -807,21 +824,6 @@ angular.module('ui.scroll', [])
               event.preventDefault();
             }
           }
-
-          // update events (deprecated since v1.1.0, unsupported since 1.2.0)
-          (() => {
-            const eventListener = datasource.scope ? datasource.scope.$new() : $scope.$new();
-
-            eventListener.$on('insert.item', () => unsupportedMethod('insert'));
-
-            eventListener.$on('update.items', () => unsupportedMethod('update'));
-
-            eventListener.$on('delete.items', () => unsupportedMethod('delete'));
-
-            function unsupportedMethod(token) {
-              throw new Error(token + ' event is no longer supported - use applyUpdates instead');
-            }
-          })();
         };
       }
     }

--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -99,7 +99,7 @@ angular.module('ui.scroll', [])
           buffer.first = origin;
           buffer.next = origin;
           buffer.minIndex = Number.MAX_VALUE;
-          return buffer.maxIndex = Number.MIN_VALUE;
+          buffer.maxIndex = Number.MIN_VALUE;
         }
 
         angular.extend(buffer, {
@@ -566,7 +566,7 @@ angular.module('ui.scroll', [])
           viewport.bind('scroll', resizeAndScrollHandler);
           viewport.bind('mousewheel', wheelHandler);
 
-          $scope.$watch(datasource.revision, () => reload());
+          $timeout(() => reload());
 
           $scope.$on('$destroy', () => {
             // clear the buffer. It is necessary to remove the elements and $destroy the scopes


### PR DESCRIPTION
Dunno why the directive was initialised with confusing `$scope.$watch(datasource.revision, () => reload());`
I didn't find use of `datasource.revision` anywhere else, so to make it clear I decided to replace it with `$timeout(() => reload());`