### PR TITLE
Add missing webpack-dev-server devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.1.0",
-    "webpack": "^1.14.0"
+    "webpack": "^1.14.0",
+    "webpack-dev-server": "^2.4.5"
   },
   "keywords": [
     "angular",


### PR DESCRIPTION
Seems the grunt task depends on webpack-dev-server, because installing it resolved the issue for me.

To replicate the issue:
1. Clean the repository of any prior installed node_modules and other changes (`git clean -xfd`)
2. Make sure webpack and webpack-dev-server node modules aren't globally installed
3. Run `npm install`
4. Run `npm run dev`

Results: This error will occur...
![webpack-dev-server-error](https://cloud.githubusercontent.com/assets/2344456/25684848/9e71d41c-3031-11e7-9150-24c6ec164aa2.png)