### PR TITLE
use $rootScope instead of $scope.$root

### DIFF
--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -349,7 +349,7 @@ angular.module('ui.scroll', [])
           let updates = updateDOM();
 
           // We need the item bindings to be processed before we can do adjustment
-          !$scope.$$phase && !$scope.$root.$$phase && $scope.$digest();
+          !$scope.$$phase && !$rootScope.$$phase && $scope.$digest();
 
           updates.inserted.forEach(w => w.element.removeClass('ng-hide'));
           updates.prepended.forEach(w => w.element.removeClass('ng-hide'));
@@ -370,7 +370,7 @@ angular.module('ui.scroll', [])
           let updates = updateDOM();
 
           // We need the item bindings to be processed before we can do adjustment
-          !$scope.$$phase && !$scope.$root.$$phase && $scope.$digest();
+          !$scope.$$phase && !$rootScope.$$phase && $scope.$digest();
 
           updates.inserted.forEach(w => w.element.removeClass('ng-hide'));
           updates.prepended.forEach(w => w.element.removeClass('ng-hide'));


### PR DESCRIPTION
@dhilt unfortunately I just found a problem with my prior PR, which has already made it out into rc.3 on npm.

Apparently, in some circumstances I don't fully understand, `$scope.$root` can be null, causing an exception in the new `$scope.$root.$$phase` check.  The fix in this PR is to check `$rootScope.$$phase` instead.

I apologize for the inconvenience, but you may want to consider merging this and then releasing a rc.4 build to get ahead of any errors this will cause.