### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 /src
 /temp
 /test
+.babelrc
 .gitignore
 .jshintrc
 .npmignore


### PR DESCRIPTION
I have babel running through some dependencies and ui-scroll causing 
```
Module build failed: Error: Couldn't find preset "env" relative to directory "..."
```

Removing the .babelrc from node_modules/angular-ui-scroll fixed my issue.