### PR TITLE
Handle failures when setting scrollTop after prepend so view does not jump

### DIFF
--- a/src/modules/jqLiteExtras.js
+++ b/src/modules/jqLiteExtras.js
@@ -255,6 +255,10 @@ export default class JQLiteExtras {
         };
       },
       scrollTop(value) {
+        if (value) {
+          this.scrollTopBeforeSet = scrollTo(this, 'top');
+          this.scrollTopValue = value;
+        }
         return scrollTo(this, 'top', value);
       },
       scrollLeft(value) {

--- a/src/modules/viewport.js
+++ b/src/modules/viewport.js
@@ -97,7 +97,7 @@ export default function Viewport(elementRoutines, buffer, element, viewportContr
     },
 
     shouldLoadTop() {
-      return !buffer.bof && (viewport.topDataPos() > viewport.topVisiblePos() - bufferPadding());
+      return !buffer.bof && !viewport.scrollTopSetFailed && viewport.topDataPos() > viewport.topVisiblePos() - bufferPadding();
     },
 
     clipTop() {
@@ -187,6 +187,7 @@ export default function Viewport(elementRoutines, buffer, element, viewportContr
       }
       else {
         topPadding.height(0);
+        viewport.scrollTopAdjust = paddingHeight;
         viewport.scrollTop(viewport.scrollTop() - paddingHeight);
       }
     },


### PR DESCRIPTION
When handling a scroll event, see if we recently set scrollTop and check whether it worked (by seeing if the current is closer to what we set it to, or the value before that). If it failed, set a flag so we don't try to keep prepending items.

The failure appears to happen primarily on Mac Chrome, and also on Safari.