### PR TITLE
startIndex rounding

### DIFF
--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -61,7 +61,8 @@ angular.module('ui.scroll', [])
         }
 
         function getIntegerNumber(value, defaultValue = 1) {
-          return isNaN(value) ? defaultValue : Math.floor(value);
+          value = value === null ? defaultValue : Math.floor(value);
+          return isNaN(value) ? defaultValue : value;
         }
 
         function parseNumericAttr(value, defaultValue) {

--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -60,20 +60,23 @@ angular.module('ui.scroll', [])
           throw new Error('Expected uiScroll in form of \'_item_ in _datasource_\' but got \'' + $attr.uiScroll + '\'');
         }
 
-        function getIntegerNumber(value, defaultValue = 1) {
-          value = value === null ? defaultValue : Math.floor(value);
+        function parseNumber(value, defaultValue, isFloat) {
+          if (!isFloat) {
+            value = value === null ? defaultValue : Math.floor(value);
+          }
           return isNaN(value) ? defaultValue : value;
         }
 
-        function parseNumericAttr(value, defaultValue) {
+        function parseNumericAttr(value, defaultValue, isFloat) {
           const result = $parse(value)($scope);
-          return getIntegerNumber(result, defaultValue);
+          return parseNumber(result, defaultValue, isFloat);
         }
 
         const BUFFER_MIN = 3;
         const BUFFER_DEFAULT = 10;
         const PADDING_MIN = 0.3;
         const PADDING_DEFAULT = 0.5;
+        const START_INDEX_DEFAULT = 1;
         const MAX_VIEWPORT_DELAY = 500;
         const VIEWPORT_POLLING_INTERVAL = 50;
 
@@ -82,8 +85,8 @@ angular.module('ui.scroll', [])
         const datasourceName = match[2];
         const viewportController = controllers[0];
         const bufferSize = Math.max(BUFFER_MIN, parseNumericAttr($attr.bufferSize, BUFFER_DEFAULT));
-        const padding = Math.max(PADDING_MIN, parseNumericAttr($attr.padding, PADDING_DEFAULT));
-        let startIndex = parseNumericAttr($attr.startIndex);
+        const padding = Math.max(PADDING_MIN, parseNumericAttr($attr.padding, PADDING_DEFAULT, true));
+        let startIndex = parseNumericAttr($attr.startIndex, START_INDEX_DEFAULT);
         let ridActual = 0; // current data revision id
         let pending = [];
 
@@ -240,7 +243,7 @@ angular.module('ui.scroll', [])
           viewport.resetTopPadding();
           viewport.resetBottomPadding();
           if (arguments.length) {
-            startIndex = getIntegerNumber(arguments[0]);
+            startIndex = parseNumber(arguments[0], START_INDEX_DEFAULT, false);
           }
           buffer.reset(startIndex);
           persistDatasourceIndex(datasource, 'minIndex');

--- a/src/ui-scroll.js
+++ b/src/ui-scroll.js
@@ -60,9 +60,13 @@ angular.module('ui.scroll', [])
           throw new Error('Expected uiScroll in form of \'_item_ in _datasource_\' but got \'' + $attr.uiScroll + '\'');
         }
 
+        function getIntegerNumber(value, defaultValue = 1) {
+          return isNaN(value) ? defaultValue : Math.floor(value);
+        }
+
         function parseNumericAttr(value, defaultValue) {
           const result = $parse(value)($scope);
-          return isNaN(result) ? defaultValue : result;
+          return getIntegerNumber(result, defaultValue);
         }
 
         const BUFFER_MIN = 3;
@@ -78,7 +82,7 @@ angular.module('ui.scroll', [])
         const viewportController = controllers[0];
         const bufferSize = Math.max(BUFFER_MIN, parseNumericAttr($attr.bufferSize, BUFFER_DEFAULT));
         const padding = Math.max(PADDING_MIN, parseNumericAttr($attr.padding, PADDING_DEFAULT));
-        let startIndex = parseNumericAttr($attr.startIndex, 1);
+        let startIndex = parseNumericAttr($attr.startIndex);
         let ridActual = 0; // current data revision id
         let pending = [];
 
@@ -235,7 +239,7 @@ angular.module('ui.scroll', [])
           viewport.resetTopPadding();
           viewport.resetBottomPadding();
           if (arguments.length) {
-            startIndex = arguments[0];
+            startIndex = getIntegerNumber(arguments[0]);
           }
           buffer.reset(startIndex);
           persistDatasourceIndex(datasource, 'minIndex');

--- a/test/AdapterTestsSpec.js
+++ b/test/AdapterTestsSpec.js
@@ -1096,6 +1096,45 @@ describe('uiScroll', function () {
       );
     });
 
+    it('should round numbers for startIndex', () => {
+      runTest(scrollSettings,
+        function (viewport, scope) {
+          scope.adapter.reload(23.4);
+          expect(scope.adapter.topVisible).toBe('item23');
+
+          scope.adapter.reload(-56.9);
+          expect(scope.adapter.topVisible).toBe('item-57');
+        }
+      );
+    });
+
+    it('should correctly convert string to number and round', () => {
+      runTest(scrollSettings,
+        function (viewport, scope) {
+          scope.adapter.reload('1001.14');
+          expect(scope.adapter.topVisible).toBe('item1001');
+
+          scope.adapter.reload('0');
+          expect(scope.adapter.topVisible).toBe('item0');
+        }
+      );
+    });
+
+    it('should set startIndex to default if number is invalid', () => {
+      runTest(scrollSettings,
+        function (viewport, scope) {
+          scope.adapter.reload('invalid number');
+          expect(scope.adapter.topVisible).toBe('item1');
+
+          scope.adapter.reload({});
+          expect(scope.adapter.topVisible).toBe('item1');
+
+          scope.adapter.reload(null);
+          expect(scope.adapter.topVisible).toBe('item1');
+        }
+      );
+    });
+
   });
 
   describe('adapter bof/eof/empty', function () {

--- a/test/UserIndicesSpec.js
+++ b/test/UserIndicesSpec.js
@@ -115,6 +115,29 @@ describe('uiScroll main/max indices', function() {
       );
     });
 
+    it('should round numbers for startIndex', () => {
+      const startIndex = 22.4;
+      runTest(Object.assign({}, scrollSettings, { startIndex }),
+        (viewport, scope) => {
+          expect(scope.adapter.topVisible).toBe('item' + Math.floor(startIndex));
+
+          const newStartIndex = 92.7;
+          scope.adapter.reload(newStartIndex);
+          expect(scope.adapter.topVisible).toBe('item' + Math.floor(newStartIndex));
+        }
+      );
+    });
+
+    it('should validate startIndex argument on reload', () => {
+      runTest(Object.assign({}, scrollSettings),
+        (viewport, scope) => {
+          const newStartIndex = 'invalid number';
+          scope.adapter.reload(newStartIndex);
+          expect(scope.adapter.topVisible).toBe('item1');
+        }
+      );
+    });
+
   });
 
   describe('Reload\n', () => {

--- a/test/UserIndicesSpec.js
+++ b/test/UserIndicesSpec.js
@@ -115,29 +115,6 @@ describe('uiScroll main/max indices', function() {
       );
     });
 
-    it('should round numbers for startIndex', () => {
-      const startIndex = 22.4;
-      runTest(Object.assign({}, scrollSettings, { startIndex }),
-        (viewport, scope) => {
-          expect(scope.adapter.topVisible).toBe('item' + Math.floor(startIndex));
-
-          const newStartIndex = 92.7;
-          scope.adapter.reload(newStartIndex);
-          expect(scope.adapter.topVisible).toBe('item' + Math.floor(newStartIndex));
-        }
-      );
-    });
-
-    it('should validate startIndex argument on reload', () => {
-      runTest(Object.assign({}, scrollSettings),
-        (viewport, scope) => {
-          const newStartIndex = 'invalid number';
-          scope.adapter.reload(newStartIndex);
-          expect(scope.adapter.topVisible).toBe('item1');
-        }
-      );
-    });
-
   });
 
   describe('Reload\n', () => {


### PR DESCRIPTION
This PR is for issue https://github.com/angular-ui/ui-scroll/issues/218. It provides `startIndex` value protection for two cases:

 - using "start-index" attribute
 - invoking `Adapter.reload(startIndex)` method